### PR TITLE
feat(tiktok): add disable long-press repost patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The goal is to keep the existing patch set usable while adding more TikTok-focus
 | `Custom offline videos limit` | Adds a custom entry to TikTok's offline videos menu with a configurable limit of up to 500 videos. |
 | `Disable login requirement` | Removes TikTok's mandatory login gate from supported flows. |
 | `Disable long-press quick share` | Keeps long-pressing Share from opening TikTok's quick-share interaction. |
+| `Disable long-press repost` | Keeps long-pressing Like from triggering TikTok's repost action and restores the 2x speed hold behaviour. |
 | `Disable screen capture detection` | Prevents TikTok from detecting screenshots and screen recordings. |
 | `Diagnostic tools` | Adds optional structured Morphe logs, Java crash capture, and clipboard or file report export. |
 | `Downloads` | Adds watermark-free downloads, filename templates, and comment sticker saving with animated-media preservation. |

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/featurecontrols/FeatureControls.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/featurecontrols/FeatureControls.java
@@ -85,6 +85,10 @@ public final class FeatureControls {
         return Settings.DISABLE_LONG_PRESS_QUICK_SHARE.get() ? 0 : originalMode;
     }
 
+    public static int overrideLongPressRepost(int originalMode) {
+        return Settings.DISABLE_LONG_PRESS_REPOST.get() ? 0 : originalMode;
+    }
+
     public static boolean enableNonPersonalizedSearch(boolean original) {
         return Settings.ENABLE_NON_PERSONALIZED_SEARCH.get() || original;
     }

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
@@ -110,6 +110,8 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting ENABLE_LONG_PRESS_SPEED_LOCK = new BooleanSetting("enable_long_press_speed_lock", FALSE, true);
     public static final BooleanSetting DISABLE_LONG_PRESS_QUICK_SHARE =
             new BooleanSetting("disable_long_press_quick_share", FALSE);
+    public static final BooleanSetting DISABLE_LONG_PRESS_REPOST =
+            new BooleanSetting("disable_long_press_repost", FALSE);
     public static final BooleanSetting ENABLE_NON_PERSONALIZED_SEARCH =
             new BooleanSetting("enable_non_personalized_search", FALSE, true);
     public static final BooleanSetting ENABLE_LIVE_SEARCH =

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
@@ -17,6 +17,7 @@ public class SettingsStatus {
     public static boolean promotionalBannersEnabled = false;
     public static boolean longPressSpeedLockEnabled = false;
     public static boolean disableLongPressQuickShareEnabled = false;
+    public static boolean disableLongPressRepostEnabled = false;
     public static boolean nonPersonalizedSearchEnabled = false;
     public static boolean liveSearchEnabled = false;
     public static boolean seekbarThumbnailEnabled = false;
@@ -68,6 +69,10 @@ public class SettingsStatus {
 
     public static void enableDisableLongPressQuickShare() {
         disableLongPressQuickShareEnabled = true;
+    }
+
+    public static void enableDisableLongPressRepost() {
+        disableLongPressRepostEnabled = true;
     }
 
     public static void enableNonPersonalizedSearch() {

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/TikTokPreferenceFragment.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/TikTokPreferenceFragment.java
@@ -450,6 +450,10 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
                 && Settings.DISABLE_LONG_PRESS_QUICK_SHARE.get()) {
             count++;
         }
+        if (SettingsStatus.disableLongPressRepostEnabled
+                && Settings.DISABLE_LONG_PRESS_REPOST.get()) {
+            count++;
+        }
         return count;
     }
 

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ExtensionPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ExtensionPreferenceCategory.java
@@ -88,6 +88,14 @@ public class ExtensionPreferenceCategory extends ConditionalPreferenceCategory {
                     Settings.DISABLE_LONG_PRESS_QUICK_SHARE
             ));
         }
+        if (SettingsStatus.disableLongPressRepostEnabled) {
+            addPreference(new TogglePreference(
+                    context,
+                    "Disable long-press repost",
+                    "Keep long-pressing Like from triggering TikTok's repost action and restore the 2x speed hold behaviour.",
+                    Settings.DISABLE_LONG_PRESS_REPOST
+            ));
+        }
         if (SettingsStatus.nonPersonalizedSearchEnabled) {
             addPreference(new TogglePreference(
                     context,

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/quickactions/DisableLongPressRepostPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/quickactions/DisableLongPressRepostPatch.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 icysymmetra/tiktok-patches-for-morphe contributors
+ * https://github.com/icysymmetra/tiktok-patches-for-morphe
+ */
+package app.morphe.patches.tiktok.interaction.quickactions
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
+import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+
+private const val FEATURE_CONTROLS_DESCRIPTOR =
+    "Lapp/morphe/extension/tiktok/featurecontrols/FeatureControls;"
+
+@Suppress("unused")
+val disableLongPressRepostPatch = bytecodePatch(
+    name = "Disable long-press repost",
+    description = "Keeps long-pressing Like from triggering TikTok's repost action and restores the 2x speed hold behaviour.",
+    default = true,
+) {
+    dependsOn(sharedExtensionPatch)
+    compatibleWith(*AppCompatibilities.tiktok4623())
+
+    execute {
+        SettingsStatusLoadFingerprint.method.addInstruction(
+            0,
+            "invoke-static {}, " +
+                "Lapp/morphe/extension/tiktok/settings/SettingsStatus;->enableDisableLongPressRepost()V",
+        )
+
+        LongPressRepostGateFingerprint.method.apply {
+            val returnIndex = indexOfFirstInstructionOrThrow {
+                opcode == Opcode.RETURN
+            }
+            addInstructions(
+                returnIndex,
+                """
+                    invoke-static {v0}, $FEATURE_CONTROLS_DESCRIPTOR->overrideLongPressRepost(I)I
+                    move-result v0
+                """,
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/quickactions/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/quickactions/Fingerprints.kt
@@ -23,3 +23,12 @@ internal object LongPressQuickShareGateFingerprint : Fingerprint(
             method.name == "LIZ"
     },
 )
+
+internal object LongPressRepostGateFingerprint : Fingerprint(
+    returnType = "I",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        classDef.type == "LX/0oDq;" &&
+            method.name == "LIZ"
+    },
+)


### PR DESCRIPTION
Long-pressing the Like button in TikTok 46.2.3 triggers a repost action instead of the previous 2x speed hold behaviour. This patch disables that by hooking the experiment gate discovered from feature gate lab that controls the `tt_upvote_experiment` AB value, forcing it to return 0 when the setting is enabled. The 2x speed hold behaviour is restored as a result.

The patch follows the same structure as Disable long-press quick share.

**Changes:**
- Added patch: `DisableLongPressRepostPatch.kt`
- Added fingerprint: `LongPressRepostGateFingerprint`
- Added setting: `DISABLE_LONG_PRESS_REPOST` (default: off)

**Test Results**

- [x] Tested on TikTok `46.2.3` with latest patches `v0.6.1`

Closes #86 