### PR TITLE
add translation filter for comments

### DIFF
--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/CommentsPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/CommentsPreferenceCategory.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceScreen;
 
 import app.morphe.extension.tiktok.settings.Settings;
 import app.morphe.extension.tiktok.settings.SettingsStatus;
+import app.morphe.extension.tiktok.settings.preference.LanguageSelectionPreference;
 import app.morphe.extension.tiktok.settings.preference.TogglePreference;
 
 @SuppressWarnings("deprecation")
@@ -29,6 +30,10 @@ public class CommentsPreferenceCategory extends ConditionalPreferenceCategory {
                     "Auto translate comments",
                     "Automatically translates loaded comment batches using TikTok's translation system.",
                     Settings.COMMENT_BATCH_TRANSLATION
+            ));
+            addPreference(new LanguageSelectionPreference(
+                    context,
+                    Settings.COMMENT_TRANSLATION_EXCLUDED_LANGUAGES
             ));
         }
         if (SettingsStatus.hideCommentQuickReactionsEnabled) {

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/translation/CommentBatchTranslator.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/translation/CommentBatchTranslator.java
@@ -355,6 +355,8 @@ public final class CommentBatchTranslator {
         String commentLanguage = primaryLanguageTag(invokeStringQuiet(comment, "getCommentLanguage"));
         if (isBlank(commentLanguage)) return false;
 
+        if (TranslationFilter.isLanguageExcluded(commentLanguage)) return true;
+
         String targetLanguage = primaryLanguageTag(getNativeTranslationTargetLanguage());
         if (!isBlank(targetLanguage) && commentLanguage.equals(targetLanguage)) return true;
 
@@ -367,6 +369,8 @@ public final class CommentBatchTranslator {
     private static String currentLanguagePolicyKey() {
         StringBuilder key = new StringBuilder("native-target:")
                 .append(value(primaryLanguageTag(getNativeTranslationTargetLanguage())))
+                .append(":custom-excluded:")
+                .append(value(Settings.COMMENT_TRANSLATION_EXCLUDED_LANGUAGES.get()))
                 .append(":dnt");
         for (String language : getNativeDoNotTranslateLanguages()) {
             key.append(':').append(value(primaryLanguageTag(language)));

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/translation/TranslationFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/translation/TranslationFilter.java
@@ -1,0 +1,125 @@
+package app.morphe.extension.tiktok.translation;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.tiktok.settings.Settings;
+
+public final class TranslationFilter {
+    private TranslationFilter() {
+    }
+
+    public static Set<String> getExcludedLanguageCodes() {
+        String settingValue = Settings.COMMENT_TRANSLATION_EXCLUDED_LANGUAGES.get();
+        if (settingValue == null || settingValue.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        Set<String> codes = new LinkedHashSet<>();
+        for (String token : settingValue.split("[,;\\s]+")) {
+            String code = primaryLanguageTag(token);
+            if (code != null && !code.isEmpty()) {
+                codes.add(code);
+            }
+        }
+        return codes;
+    }
+
+    public static boolean isLanguageExcluded(String languageCode) {
+        String primary = primaryLanguageTag(languageCode);
+        if (primary == null || primary.isEmpty()) {
+            return false;
+        }
+        return getExcludedLanguageCodes().contains(primary);
+    }
+
+    public static boolean shouldSkipCommentTranslation(Object comment) {
+        if (comment == null) return false;
+        String commentLanguage = primaryLanguageTag(invokeStringQuiet(comment, "getCommentLanguage"));
+        if (isBlank(commentLanguage)) return false;
+
+        return isLanguageExcluded(commentLanguage);
+    }
+
+    public static boolean shouldSkipAwemeTranslation(Object aweme, String srcLang) {
+        String language = primaryLanguageTag(srcLang);
+        if (isBlank(language) && aweme != null) {
+            language = extractAwemeLanguage(aweme);
+        }
+
+        if (isBlank(language)) return false;
+        return isLanguageExcluded(language);
+    }
+
+    public static boolean shouldSkipAwemeTranslation(Object param1, Object param2, Object param3) {
+        Object aweme = null;
+        String srcLang = null;
+
+        if (param1 != null && param1.getClass().getName().contains("Aweme")) {
+            aweme = param1;
+        } else if (param2 != null && param2.getClass().getName().contains("Aweme")) {
+            aweme = param2;
+        }
+
+        if (param2 instanceof String) {
+            srcLang = (String) param2;
+        } else if (param3 instanceof String) {
+            srcLang = (String) param3;
+        }
+
+        return shouldSkipAwemeTranslation(aweme, srcLang);
+    }
+
+    public static String extractAwemeLanguage(Object aweme) {
+        if (aweme == null) return null;
+        String[] candidateMethods = {
+            "getCaptionLanguage",
+            "getOriginalLanguage",
+            "getLanguage",
+            "getSrcLanguage"
+        };
+        for (String methodName : candidateMethods) {
+            String lang = invokeStringQuiet(aweme, methodName);
+            if (!isBlank(lang)) {
+                return primaryLanguageTag(lang);
+            }
+        }
+        return null;
+    }
+
+    public static String primaryLanguageTag(String language) {
+        if (isBlank(language)) return null;
+
+        String normalized = language.trim().replace('_', '-').toLowerCase(Locale.ROOT);
+        int separatorIndex = normalized.indexOf('-');
+        if (separatorIndex > 0) {
+            normalized = normalized.substring(0, separatorIndex);
+        }
+
+        if ("in".equals(normalized)) normalized = "id";
+        if ("iw".equals(normalized)) normalized = "he";
+        if ("ji".equals(normalized)) normalized = "yi";
+        if ("und".equals(normalized)) return null;
+
+        return normalized;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static String invokeStringQuiet(Object instance, String methodName) {
+        if (instance == null) return null;
+        try {
+            Method method = instance.getClass().getMethod(methodName);
+            Object value = method.invoke(instance);
+            return value == null ? null : String.valueOf(value);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/translation/CommentTranslationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/translation/CommentTranslationPatch.kt
@@ -15,6 +15,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 private const val EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/translation/CommentBatchTranslator;"
+private const val FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/translation/TranslationFilter;"
 
 @Suppress("unused")
 val commentTranslationPatch = bytecodePatch(
@@ -105,6 +106,42 @@ val commentTranslationPatch = bytecodePatch(
             0,
             """
                 invoke-static {p0}, $EXTENSION_CLASS_DESCRIPTOR->onNativeBatchComplete(Ljava/lang/Object;)V
+            """,
+        )
+
+        TranslationServiceCommentLanguageAllowedFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                invoke-static {p1}, $FILTER_CLASS_DESCRIPTOR->shouldSkipCommentTranslation(Ljava/lang/Object;)Z
+                move-result v0
+                if-eqz v0, :skip_comment_lang
+                const/4 v0, 0x0
+                return v0
+                :skip_comment_lang
+            """,
+        )
+
+        TranslationServiceCommentTranslatableFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                invoke-static {p1}, $FILTER_CLASS_DESCRIPTOR->shouldSkipCommentTranslation(Ljava/lang/Object;)Z
+                move-result v0
+                if-eqz v0, :skip_comment_trans
+                const/4 v0, 0x0
+                return v0
+                :skip_comment_trans
+            """,
+        )
+
+        TranslationServiceAwemeTranslationRequestFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                invoke-static {p2, p3, p4}, $FILTER_CLASS_DESCRIPTOR->shouldSkipAwemeTranslation(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+                move-result v0
+                if-eqz v0, :skip_aweme_trans
+                const/4 v0, 0x0
+                return-object v0
+                :skip_aweme_trans
             """,
         )
     }


### PR DESCRIPTION
Closes https://github.com/icysymmetra/tiktok-patches-for-morphe/issues/102

Summary
- Added TranslationFilter.java to support comment translation exclusions and custom language filtering.
- Fixed local Gradle build credentials resolution in settings.gradle.kts when GITHUB_ACTOR/GITHUB_TOKEN environment variables are not present.



<details> 

_(Made with AI cuz I couldn't wait)_

 </details>