### PR TITLE
feat: add share sheet modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The goal is to keep the existing patch set usable while adding more TikTok-focus
 | `Region spoof` | Adds in-app controls for changing the region identity values TikTok reads. TikTok may still use IP address, account history, language, and other region signals. |
 | `Sanitize sharing links` | Removes tracking parameters from TikTok links before they are shared. |
 | `Settings` | Adds the Metra patches settings screen inside TikTok. |
+| `Share sheet modification` | Toggles the share sheet's "Send to", "Share via app", and "Video Actions" sections, with an allow-list for which apps and actions appear in the latter two. |
 | `Show seekbar` | Shows TikTok's native video seekbar where it would normally be hidden. |
 | `Show seekbar thumbnail` | Shows TikTok's video preview thumbnail while dragging the seekbar. |
 | `Stop video looping` | Stops a completed video instead of automatically replaying it. |

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
@@ -16,6 +16,8 @@ import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.shared.settings.StringSetting;
 import app.morphe.extension.tiktok.navigation.BottomNavigationTabOptions;
 import app.morphe.extension.tiktok.navigation.NavigationTabOptions;
+import app.morphe.extension.tiktok.sharesheet.ShareChannelOptions;
+import app.morphe.extension.tiktok.sharesheet.VideoActionOptions;
 
 public class Settings extends BaseSettings {
     public static final BooleanSetting REMOVE_ADS = new BooleanSetting("remove_ads", TRUE, true);
@@ -134,6 +136,33 @@ public class Settings extends BaseSettings {
     public static final StringSetting SIM_SPOOF_ISO = new StringSetting("simspoof_iso", "us");
     public static final StringSetting SIMSPOOF_MCCMNC = new StringSetting("simspoof_mccmnc", "310260");
     public static final StringSetting SIMSPOOF_OP_NAME = new StringSetting("simspoof_op_name", "T-Mobile");
+    public static final BooleanSetting SHARE_SHEET_SEND_TO = new BooleanSetting("share_sheet_send_to", TRUE, true);
+    public static final BooleanSetting SHARE_SHEET_CHANNELS = new BooleanSetting("share_sheet_channels", TRUE, true);
+    public static final StringSetting SHARE_SHEET_CHANNELS_ENABLED = new StringSetting(
+            "share_sheet_channels_enabled",
+            ShareChannelOptions.defaultEnabledKeys(),
+            true,
+            Setting.parent(SHARE_SHEET_CHANNELS)
+    );
+    public static final StringSetting SHARE_SHEET_CHANNELS_OBSERVED = new StringSetting(
+            "share_sheet_channels_observed",
+            "",
+            false,
+            false
+    );
+    public static final BooleanSetting SHARE_SHEET_ACTIONS = new BooleanSetting("share_sheet_actions", TRUE, true);
+    public static final StringSetting SHARE_SHEET_ACTIONS_ENABLED = new StringSetting(
+            "share_sheet_actions_enabled",
+            VideoActionOptions.defaultEnabledKeys(),
+            true,
+            Setting.parent(SHARE_SHEET_ACTIONS)
+    );
+    public static final StringSetting SHARE_SHEET_ACTIONS_OBSERVED = new StringSetting(
+            "share_sheet_actions_observed",
+            "",
+            false,
+            false
+    );
 
     static {
         if (!DOWNLOAD_PATHS_MIGRATED.get()) {

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
@@ -26,6 +26,7 @@ public class SettingsStatus {
     public static boolean externalBrowserEnabled = false;
     public static boolean alwaysShowPublishDateEnabled = false;
     public static boolean diagnosticsEnabled = false;
+    public static boolean shareSheetEnabled = false;
 
     public static void enableFeedFilter() {
         feedFilterEnabled = true;
@@ -105,6 +106,10 @@ public class SettingsStatus {
 
     public static void enableDiagnostics() {
         diagnosticsEnabled = true;
+    }
+
+    public static void enableShareSheet() {
+        shareSheetEnabled = true;
     }
 
     public static void load() {

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/SettingsMenuPreference.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/SettingsMenuPreference.java
@@ -35,7 +35,8 @@ public final class SettingsMenuPreference extends Preference {
         REGION,
         BEHAVIOR,
         LAB,
-        DIAGNOSTICS
+        DIAGNOSTICS,
+        SHARE
     }
 
     private static final int ACCESSORY_TAG = 0x4D4D454E;
@@ -274,6 +275,7 @@ public final class SettingsMenuPreference extends Preference {
         private final Paint fill = new Paint(Paint.ANTI_ALIAS_FLAG);
         private final Paint border = new Paint(Paint.ANTI_ALIAS_FLAG);
         private final Paint line = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final Paint glyphFill = new Paint(Paint.ANTI_ALIAS_FLAG);
         private final Path path = new Path();
 
         MenuIconDrawable(Icon icon) {
@@ -293,6 +295,8 @@ public final class SettingsMenuPreference extends Preference {
             line.setStrokeWidth(1.8f);
             line.setStrokeCap(Paint.Cap.ROUND);
             line.setStrokeJoin(Paint.Join.ROUND);
+            glyphFill.setColor(line.getColor());
+            glyphFill.setStyle(Paint.Style.FILL);
         }
 
         @Override
@@ -383,6 +387,56 @@ public final class SettingsMenuPreference extends Preference {
                     canvas.drawLine(left, cy, cx - bounds.width() * 0.16f, cy, line);
                     canvas.drawLine(cx + bounds.width() * 0.16f, cy, right, cy, line);
                     break;
+                case SHARE: {
+                    // Traced from a 24x24 "share" glyph (svgrepo.com); coordinates below are
+                    // that glyph's own path data, mapped 1:1 from its viewBox into this tile.
+                    float pad = bounds.width() * 0.20f;
+                    float s = (bounds.width() - pad * 2f) / 24f;
+                    float ox = bounds.left + pad;
+                    float oy = bounds.top + pad;
+
+                    path.reset();
+                    path.setFillType(Path.FillType.EVEN_ODD);
+
+                    path.moveTo(ox + 1f * s, oy + 18.5088f * s);
+                    path.cubicTo(ox + 1f * s, oy + 13.1679f * s, ox + 4.90169f * s, oy + 8.77098f * s, ox + 9.99995f * s, oy + 7.84598f * s);
+                    path.lineTo(ox + 9.99995f * s, oy + 5.51119f * s);
+                    path.cubicTo(ox + 9.99995f * s, oy + 3.63887f * s, ox + 12.1534f * s, oy + 2.58563f * s, ox + 13.6313f * s, oy + 3.73514f * s);
+                    path.lineTo(ox + 21.9742f * s, oy + 10.224f * s);
+                    path.cubicTo(ox + 23.1323f * s, oy + 11.1248f * s, ox + 23.1324f * s, oy + 12.8752f * s, ox + 21.9742f * s, oy + 13.7761f * s);
+                    path.lineTo(ox + 13.6314f * s, oy + 20.2649f * s);
+                    path.cubicTo(ox + 12.1534f * s, oy + 21.4144f * s, ox + 10f * s, oy + 20.3612f * s, ox + 10f * s, oy + 18.4888f * s);
+                    path.lineTo(ox + 10f * s, oy + 16.5189f * s);
+                    path.cubicTo(ox + 7.74106f * s, oy + 16.9525f * s, ox + 5.9625f * s, oy + 18.1157f * s, ox + 4.92778f * s, oy + 19.6838f * s);
+                    path.cubicTo(ox + 4.33222f * s, oy + 20.5863f * s, ox + 3.30568f * s, oy + 20.7735f * s, ox + 2.55965f * s, oy + 20.5635f * s);
+                    path.cubicTo(ox + 1.80473f * s, oy + 20.3511f * s, ox + 1.00011f * s, oy + 19.6306f * s, ox + 1f * s, oy + 18.5088f * s);
+                    path.close();
+
+                    path.moveTo(ox + 12.4034f * s, oy + 5.31385f * s);
+                    path.cubicTo(ox + 12.2392f * s, oy + 5.18613f * s, ox + 11.9999f * s, oy + 5.30315f * s, ox + 11.9999f * s, oy + 5.51119f * s);
+                    path.lineTo(ox + 11.9999f * s, oy + 9.41672f * s);
+                    path.cubicTo(ox + 11.9999f * s, oy + 9.55479f * s, ox + 11.8873f * s, oy + 9.66637f * s, ox + 11.7493f * s, oy + 9.67008f * s);
+                    path.cubicTo(ox + 8.09094f * s, oy + 9.76836f * s, ox + 4.97774f * s, oy + 12.0115f * s, ox + 3.66558f * s, oy + 15.1656f * s);
+                    path.cubicTo(ox + 3.46812f * s, oy + 15.6402f * s, ox + 3.31145f * s, oy + 16.1354f * s, ox + 3.19984f * s, oy + 16.6471f * s);
+                    path.cubicTo(ox + 3.07554f * s, oy + 17.217f * s, ox + 3.00713f * s, oy + 17.8072f * s, ox + 3.00053f * s, oy + 18.412f * s);
+                    path.cubicTo(ox + 3.00018f * s, oy + 18.4442f * s, ox + 3f * s, oy + 18.4765f * s, ox + 3f * s, oy + 18.5088f * s);
+                    path.cubicTo(ox + 3.00001f * s, oy + 18.6437f * s, ox + 3.18418f * s, oy + 18.6948f * s, ox + 3.25846f * s, oy + 18.5822f * s);
+                    path.cubicTo(ox + 3.27467f * s, oy + 18.5577f * s, ox + 3.29101f * s, oy + 18.5332f * s, ox + 3.30747f * s, oy + 18.5088f * s);
+                    path.cubicTo(ox + 3.30748f * s, oy + 18.5088f * s, ox + 3.30746f * s, oy + 18.5088f * s, ox + 3.30747f * s, oy + 18.5088f * s);
+                    path.cubicTo(ox + 3.63446f * s, oy + 18.0244f * s, ox + 4.01059f * s, oy + 17.5765f * s, ox + 4.42994f * s, oy + 17.168f * s);
+                    path.cubicTo(ox + 4.71487f * s, oy + 16.8905f * s, ox + 5.01975f * s, oy + 16.6313f * s, ox + 5.34276f * s, oy + 16.3912f * s);
+                    path.cubicTo(ox + 7.05882f * s, oy + 15.1158f * s, ox + 9.28642f * s, oy + 14.3823f * s, ox + 11.7496f * s, oy + 14.3357f * s);
+                    path.cubicTo(ox + 11.8877f * s, oy + 14.3331f * s, ox + 12f * s, oy + 14.4453f * s, ox + 12f * s, oy + 14.5834f * s);
+                    path.lineTo(ox + 12f * s, oy + 18.4888f * s);
+                    path.cubicTo(ox + 12f * s, oy + 18.6969f * s, ox + 12.2393f * s, oy + 18.8139f * s, ox + 12.4035f * s, oy + 18.6862f * s);
+                    path.lineTo(ox + 20.7463f * s, oy + 12.1973f * s);
+                    path.cubicTo(ox + 20.875f * s, oy + 12.0973f * s, ox + 20.875f * s, oy + 11.9028f * s, ox + 20.7463f * s, oy + 11.8027f * s);
+                    path.lineTo(ox + 12.4034f * s, oy + 5.31385f * s);
+                    path.close();
+
+                    canvas.drawPath(path, glyphFill);
+                    break;
+                }
             }
         }
 
@@ -391,6 +445,7 @@ public final class SettingsMenuPreference extends Preference {
             fill.setAlpha(alpha);
             border.setAlpha(alpha);
             line.setAlpha(alpha);
+            glyphFill.setAlpha(alpha);
         }
 
         @Override
@@ -398,6 +453,7 @@ public final class SettingsMenuPreference extends Preference {
             fill.setColorFilter(colorFilter);
             border.setColorFilter(colorFilter);
             line.setColorFilter(colorFilter);
+            glyphFill.setColorFilter(colorFilter);
         }
 
         @Override

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/SettingsMenuPreference.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/SettingsMenuPreference.java
@@ -388,8 +388,6 @@ public final class SettingsMenuPreference extends Preference {
                     canvas.drawLine(cx + bounds.width() * 0.16f, cy, right, cy, line);
                     break;
                 case SHARE: {
-                    // Traced from a 24x24 "share" glyph (svgrepo.com); coordinates below are
-                    // that glyph's own path data, mapped 1:1 from its viewBox into this tile.
                     float pad = bounds.width() * 0.20f;
                     float s = (bounds.width() - pad * 2f) / 24f;
                     float ox = bounds.left + pad;

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/ShareSheetItemSelectionPreference.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/ShareSheetItemSelectionPreference.java
@@ -1,0 +1,329 @@
+package app.morphe.extension.tiktok.settings.preference;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.preference.Preference;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import app.morphe.extension.shared.settings.StringSetting;
+import app.morphe.extension.shared.settings.preference.AbstractPreferenceFragment;
+
+/**
+ * Checkbox-dialog multi-select preference generalized over an item catalog via plain
+ * functions, so one class serves both channels and actions. Mirrors {@link TabSelectionPreference}.
+ */
+@SuppressWarnings("deprecation")
+public class ShareSheetItemSelectionPreference extends Preference {
+    private final StringSetting setting;
+    private final String dialogTitle;
+    private final String helperText;
+    private final Function<String, Set<String>> parseEnabledKeys;
+    private final Function<Set<String>, String> serializeEnabledKeys;
+    private final Function<Set<String>, List<Row>> optionsForKeys;
+    private final Set<String> knownKeys;
+    private String value;
+    private boolean valueSet;
+
+    public ShareSheetItemSelectionPreference(
+            Context context,
+            String title,
+            String dialogTitle,
+            String helperText,
+            StringSetting setting,
+            Function<String, Set<String>> parseEnabledKeys,
+            Function<Set<String>, String> serializeEnabledKeys,
+            Function<Set<String>, List<Row>> optionsForKeys,
+            Set<String> knownKeys
+    ) {
+        super(context);
+        this.dialogTitle = dialogTitle;
+        this.helperText = helperText;
+        this.setting = setting;
+        this.parseEnabledKeys = parseEnabledKeys;
+        this.serializeEnabledKeys = serializeEnabledKeys;
+        this.optionsForKeys = optionsForKeys;
+        this.knownKeys = knownKeys;
+        setTitle(title);
+        setKey(setting.key);
+        setValue(setting.get());
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public boolean setValue(String value) {
+        String sanitizedValue = serializeEnabledKeys.apply(parseEnabledKeys.apply(value));
+        boolean changed = !TextUtils.equals(this.value, sanitizedValue);
+        if (changed || !valueSet) {
+            this.value = sanitizedValue;
+            valueSet = true;
+            setting.save(sanitizedValue);
+            refreshSummary();
+            if (changed) {
+                notifyDependencyChange(shouldDisableDependents());
+                notifyChanged();
+            }
+        }
+        return changed;
+    }
+
+    @Override
+    protected void onClick() {
+        showSelectionDialog();
+    }
+
+    @Override
+    protected void onBindView(View view) {
+        super.onBindView(view);
+        app.morphe.extension.tiktok.Utils.setTitleAndSummaryColor(view);
+    }
+
+    private void refreshSummary() {
+        Set<String> selected = parseEnabledKeys.apply(value);
+        List<Row> allRows = optionsForKeys.apply(knownKeys);
+        if (allRows.isEmpty()) {
+            setSummary("All");
+            return;
+        }
+
+        int selectedCount = 0;
+        StringBuilder builder = new StringBuilder();
+        for (Row row : allRows) {
+            if (!selected.contains(row.key)) {
+                continue;
+            }
+            selectedCount++;
+            if (builder.length() > 0) {
+                builder.append(", ");
+            }
+            builder.append(row.label);
+        }
+
+        if (selectedCount == allRows.size()) {
+            setSummary("All");
+            return;
+        }
+        if (builder.length() == 0) {
+            setSummary("None");
+            return;
+        }
+        setSummary(builder.toString());
+    }
+
+    private void showSelectionDialog() {
+        Context context = getContext();
+        Set<String> selected = new LinkedHashSet<>(parseEnabledKeys.apply(value));
+        List<Row> rows = optionsForKeys.apply(knownKeys);
+
+        LinearLayout dialogView = new LinearLayout(context);
+        dialogView.setOrientation(LinearLayout.VERTICAL);
+        dialogView.setBackground(createDialogBackground());
+        int padding = dpToPx(22);
+        dialogView.setPadding(padding, padding, padding, padding);
+
+        TextView title = new TextView(context);
+        title.setText(dialogTitle);
+        title.setTextColor(getTitleTextColor());
+        title.setTextSize(20);
+        title.setTypeface(title.getTypeface(), Typeface.BOLD);
+        dialogView.addView(title, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        TextView helper = new TextView(context);
+        helper.setText(helperText);
+        helper.setTextColor(getSummaryTextColor());
+        LinearLayout.LayoutParams helperParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        helperParams.setMargins(0, dpToPx(16), 0, dpToPx(12));
+        dialogView.addView(helper, helperParams);
+
+        LinearLayout optionsContainer = new LinearLayout(context);
+        optionsContainer.setOrientation(LinearLayout.VERTICAL);
+        optionsContainer.setBackground(createListBackground());
+        int optionInset = Math.max(1, dpToPx(1));
+        optionsContainer.setPadding(optionInset, optionInset, optionInset, optionInset);
+
+        for (Row row : rows) {
+            optionsContainer.addView(createOptionRow(context, selected, row));
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(false);
+        scrollView.addView(optionsContainer, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        LinearLayout.LayoutParams scrollParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                SettingsUi.dialogListHeight(context, 380)
+        );
+        scrollParams.setMargins(0, 0, 0, dpToPx(16));
+        dialogView.addView(scrollView, scrollParams);
+
+        LinearLayout actions = new LinearLayout(context);
+        actions.setGravity(Gravity.CENTER_VERTICAL);
+
+        TextView selectAllButton = createActionButton(context, "Select all", false);
+        TextView cancelButton = createActionButton(context, "Cancel", false);
+        TextView saveButton = createActionButton(context, "Save", true);
+
+        actions.addView(selectAllButton, new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1
+        ));
+        actions.addView(cancelButton);
+        actions.addView(saveButton);
+        dialogView.addView(actions, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        AlertDialog dialog = new AlertDialog.Builder(context)
+                .setView(dialogView)
+                .create();
+
+        selectAllButton.setOnClickListener(view -> {
+            selected.clear();
+            for (Row row : rows) {
+                selected.add(row.key);
+            }
+            boolean changed = setValue(serializeEnabledKeys.apply(selected));
+            dialog.dismiss();
+            if (changed && setting.rebootApp) {
+                AbstractPreferenceFragment.showRestartDialog(context);
+            }
+        });
+        cancelButton.setOnClickListener(view -> dialog.dismiss());
+        saveButton.setOnClickListener(view -> {
+            boolean changed = setValue(serializeEnabledKeys.apply(selected));
+            dialog.dismiss();
+            if (changed && setting.rebootApp) {
+                AbstractPreferenceFragment.showRestartDialog(context);
+            }
+        });
+
+        dialog.show();
+        SettingsUi.styleDialog(dialog);
+    }
+
+    private View createOptionRow(Context context, Set<String> selected, Row row) {
+        LinearLayout rowView = new LinearLayout(context);
+        rowView.setOrientation(LinearLayout.HORIZONTAL);
+        rowView.setGravity(Gravity.CENTER_VERTICAL);
+        rowView.setBackgroundColor(getDialogBackgroundColor());
+        rowView.setPadding(dpToPx(10), dpToPx(10), dpToPx(10), dpToPx(10));
+
+        CheckBox checkBox = new CheckBox(context);
+        checkBox.setChecked(selected.contains(row.key));
+        checkBox.setClickable(false);
+        SettingsUi.styleCheckBox(checkBox);
+        rowView.addView(checkBox, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        TextView label = new TextView(context);
+        label.setText(row.label);
+        label.setTextColor(getTitleTextColor());
+        label.setTextSize(16);
+        rowView.addView(label, new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1
+        ));
+
+        rowView.setOnClickListener(view -> {
+            if (selected.contains(row.key)) {
+                selected.remove(row.key);
+                checkBox.setChecked(false);
+            } else {
+                selected.add(row.key);
+                checkBox.setChecked(true);
+            }
+        });
+
+        View divider = new View(context);
+        divider.setBackgroundColor(getDialogDividerColor());
+
+        LinearLayout wrapper = new LinearLayout(context);
+        wrapper.setOrientation(LinearLayout.VERTICAL);
+        wrapper.addView(rowView, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        wrapper.addView(divider, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                Math.max(1, dpToPx(1))
+        ));
+        return wrapper;
+    }
+
+    private TextView createActionButton(Context context, String text, boolean primary) {
+        TextView button = new TextView(context);
+        button.setText(text);
+        button.setTextSize(16);
+        button.setGravity(Gravity.CENTER);
+        button.setPadding(dpToPx(12), dpToPx(8), dpToPx(12), dpToPx(6));
+        SettingsUi.styleTextAction(button, primary);
+        return button;
+    }
+
+    private int dpToPx(int dp) {
+        return Math.round(dp * getContext().getResources().getDisplayMetrics().density);
+    }
+
+    private GradientDrawable createDialogBackground() {
+        return SettingsUi.borderedSurface(getContext(), 6, true);
+    }
+
+    private GradientDrawable createListBackground() {
+        return SettingsUi.borderedSurface(getContext(), 4, false);
+    }
+
+    private static int getDialogBackgroundColor() {
+        return SettingsUi.surface();
+    }
+
+    private static int getDialogDividerColor() {
+        return SettingsUi.divider();
+    }
+
+    private static int getTitleTextColor() {
+        return SettingsUi.textPrimary();
+    }
+
+    private static int getSummaryTextColor() {
+        return SettingsUi.textSecondary();
+    }
+
+    public static final class Row {
+        public final String key;
+        public final String label;
+
+        public Row(String key, String label) {
+            this.key = key;
+            this.label = label;
+        }
+    }
+}

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/TikTokPreferenceFragment.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/TikTokPreferenceFragment.java
@@ -40,6 +40,7 @@ import app.morphe.extension.tiktok.settings.preference.categories.ExtensionPrefe
 import app.morphe.extension.tiktok.settings.preference.categories.FeedFilterPreferenceCategory;
 import app.morphe.extension.tiktok.settings.preference.categories.FeedNavigationPreferenceCategory;
 import app.morphe.extension.tiktok.settings.preference.categories.InterfacePreferenceCategory;
+import app.morphe.extension.tiktok.settings.preference.categories.ShareSheetPreferenceCategory;
 import app.morphe.extension.tiktok.settings.preference.categories.SimSpoofPreferenceCategory;
 
 @SuppressWarnings("deprecation")
@@ -56,6 +57,7 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
         COMMENTS("Comments and translation", "Auto translate, quick reactions, and copy options."),
         DOWNLOADS("Downloads", "Path, watermark, and offline videos."),
         REGION("Region spoof", "Change the region TikTok reads."),
+        SHARE_SHEET("Share sheet", "Send to, share via app, and video actions."),
         BEHAVIOR("App behavior", "Sharing, playback, and gestures."),
         DIAGNOSTICS("Diagnostics", "Logging, crash capture, and report export.");
 
@@ -134,6 +136,13 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
             } else {
                 Setting.privateSetValueFromString(setting, languagePreference.getValue());
             }
+        } else if (pref instanceof ShareSheetItemSelectionPreference) {
+            ShareSheetItemSelectionPreference shareSheetItemPref = (ShareSheetItemSelectionPreference) pref;
+            if (applySettingToPreference) {
+                shareSheetItemPref.setValue(setting.get().toString());
+            } else {
+                Setting.privateSetValueFromString(setting, shareSheetItemPref.getValue());
+            }
         } else {
             super.syncSettingWithPreference(pref, setting, applySettingToPreference);
         }
@@ -156,6 +165,9 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
         }
         if (pref instanceof LanguageSelectionPreference) {
             return defaultValue.equals(((LanguageSelectionPreference) pref).getValue());
+        }
+        if (pref instanceof ShareSheetItemSelectionPreference) {
+            return defaultValue.equals(((ShareSheetItemSelectionPreference) pref).getValue());
         }
 
         return super.prefIsSetToDefault(pref, setting);
@@ -290,6 +302,13 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
                     Settings.SIM_SPOOF.get()
             ));
         }
+        if (SettingsStatus.shareSheetEnabled) {
+            addMenu(screen, Section.SHARE_SHEET, SettingsMenuPreference.Icon.SHARE, countEnabled(
+                    Settings.SHARE_SHEET_SEND_TO.get(),
+                    Settings.SHARE_SHEET_CHANNELS.get(),
+                    Settings.SHARE_SHEET_ACTIONS.get()
+            ));
+        }
 
         addMenu(screen, Section.BEHAVIOR, SettingsMenuPreference.Icon.BEHAVIOR, countBehaviorSettings());
 
@@ -359,6 +378,9 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
                 break;
             case REGION:
                 category = new SimSpoofPreferenceCategory(context, screen);
+                break;
+            case SHARE_SHEET:
+                category = new ShareSheetPreferenceCategory(context, screen);
                 break;
             case DIAGNOSTICS:
                 category = new DebugPreferenceCategory(context, screen);

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ShareSheetPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ShareSheetPreferenceCategory.java
@@ -1,0 +1,104 @@
+package app.morphe.extension.tiktok.settings.preference.categories;
+
+import android.content.Context;
+import android.preference.PreferenceScreen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import app.morphe.extension.tiktok.settings.Settings;
+import app.morphe.extension.tiktok.settings.SettingsStatus;
+import app.morphe.extension.tiktok.settings.preference.ShareSheetItemSelectionPreference;
+import app.morphe.extension.tiktok.settings.preference.TogglePreference;
+import app.morphe.extension.tiktok.sharesheet.ShareChannelOptions;
+import app.morphe.extension.tiktok.sharesheet.VideoActionOptions;
+
+@SuppressWarnings("deprecation")
+public class ShareSheetPreferenceCategory extends ConditionalPreferenceCategory {
+    public ShareSheetPreferenceCategory(Context context, PreferenceScreen screen) {
+        super(context, screen);
+        setTitle("Share sheet");
+    }
+
+    @Override
+    public boolean getSettingsStatus() {
+        return SettingsStatus.shareSheetEnabled;
+    }
+
+    @Override
+    public void addPreferences(Context context) {
+        addPreference(new TogglePreference(
+                context,
+                "Show \"Send to\"",
+                "Show quick-share contacts at the top of the share sheet.",
+                Settings.SHARE_SHEET_SEND_TO
+        ));
+
+        addPreference(new TogglePreference(
+                context,
+                "Show \"Share via\"",
+                "Show the row of sharing apps (Repost, Copy link, Discord, WhatsApp, ...).",
+                Settings.SHARE_SHEET_CHANNELS
+        ));
+        addPreference(new ShareSheetItemSelectionPreference(
+                context,
+                "Allowed sharing apps",
+                "Allowed sharing apps",
+                "Only apps checked here appear in \"Share via\". Apps TikTok adds later show up automatically.",
+                Settings.SHARE_SHEET_CHANNELS_ENABLED,
+                ShareChannelOptions::parseEnabledKeys,
+                ShareChannelOptions::serializeEnabledKeys,
+                keys -> toRows(ShareChannelOptions.optionsForKeys(keys)),
+                observedChannelKeys()
+        ));
+
+        addPreference(new TogglePreference(
+                context,
+                "Show video actions",
+                "Show the actions grid (Report, Download, Duet, Stitch, Playback Speed, ...).",
+                Settings.SHARE_SHEET_ACTIONS
+        ));
+        addPreference(new ShareSheetItemSelectionPreference(
+                context,
+                "Allowed video actions",
+                "Allowed video actions",
+                "Only actions checked here appear in \"Video Actions\". Actions TikTok adds later show up automatically.",
+                Settings.SHARE_SHEET_ACTIONS_ENABLED,
+                VideoActionOptions::parseEnabledKeys,
+                VideoActionOptions::serializeEnabledKeys,
+                keys -> toRowsFromActions(VideoActionOptions.optionsForKeys(keys)),
+                observedActionKeys()
+        ));
+    }
+
+    private static Set<String> observedChannelKeys() {
+        Set<String> keys = ShareChannelOptions.parseEnabledKeys(Settings.SHARE_SHEET_CHANNELS_ENABLED.get());
+        keys.addAll(ShareChannelOptions.parseObservedKeys(Settings.SHARE_SHEET_CHANNELS_OBSERVED.get()));
+        return keys;
+    }
+
+    private static Set<String> observedActionKeys() {
+        Set<String> keys = VideoActionOptions.parseEnabledKeys(Settings.SHARE_SHEET_ACTIONS_ENABLED.get());
+        keys.addAll(VideoActionOptions.parseObservedKeys(Settings.SHARE_SHEET_ACTIONS_OBSERVED.get()));
+        return keys;
+    }
+
+    private static List<ShareSheetItemSelectionPreference.Row> toRows(List<ShareChannelOptions.Option> options) {
+        List<ShareSheetItemSelectionPreference.Row> rows = new ArrayList<>();
+        for (ShareChannelOptions.Option option : options) {
+            rows.add(new ShareSheetItemSelectionPreference.Row(option.key, option.label));
+        }
+        return rows;
+    }
+
+    private static List<ShareSheetItemSelectionPreference.Row> toRowsFromActions(
+            List<VideoActionOptions.Option> options
+    ) {
+        List<ShareSheetItemSelectionPreference.Row> rows = new ArrayList<>();
+        for (VideoActionOptions.Option option : options) {
+            rows.add(new ShareSheetItemSelectionPreference.Row(option.key, option.label));
+        }
+        return rows;
+    }
+}

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ShareSheetPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ShareSheetPreferenceCategory.java
@@ -55,7 +55,7 @@ public class ShareSheetPreferenceCategory extends ConditionalPreferenceCategory 
 
         addPreference(new TogglePreference(
                 context,
-                "Show video actions",
+                "Show \"Video Actions\"",
                 "Show the actions grid (Report, Download, Duet, Stitch, Playback Speed, ...).",
                 Settings.SHARE_SHEET_ACTIONS
         ));

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/sharesheet/ShareChannelOptions.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/sharesheet/ShareChannelOptions.java
@@ -1,0 +1,191 @@
+package app.morphe.extension.tiktok.sharesheet;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Known "Share via" channel keys, sourced from TikTok's
+ * {@code com.ss.android.ugc.aweme.channel.share.channelservice.*ChannelService} classes.
+ * Channels not seeded here are picked up automatically the first time they're observed;
+ * see {@link ShareSheetFilter}.
+ */
+public final class ShareChannelOptions {
+    private static final String RAW_PREFIX = "RAW:";
+
+    public static final Option[] OPTIONS = {
+            new Option("repost", "Repost"),
+            new Option("copy", "Copy Link"),
+            new Option("ai_remix", "AI Remix"),
+            new Option("live_repost_note", "Live Repost Add Note"),
+            new Option("chat_merge", "Chat Merge"),
+            new Option("qr_code", "QR Code"),
+            new Option("sms", "SMS"),
+            new Option("email", "Email"),
+            new Option("facebook", "Facebook"),
+            new Option("facebook_lite", "Facebook Lite"),
+            new Option("facebook_group", "Facebook Group"),
+            new Option("facebook_story", "Facebook Story"),
+            new Option("messenger", "Messenger"),
+            new Option("messenger_lite", "Messenger Lite"),
+            new Option("instagram", "Instagram"),
+            new Option("instagram_story", "Instagram Story"),
+            new Option("instagram_dm", "Instagram DM"),
+            new Option("whatsapp", "WhatsApp"),
+            new Option("whatsapp_business", "WhatsApp Business"),
+            new Option("whatsapp_status", "WhatsApp Status"),
+            new Option("telegram", "Telegram"),
+            new Option("twitter", "X (Twitter)"),
+            new Option("snapchat", "Snapchat"),
+            new Option("snapchat_chats", "Snapchat Chats"),
+            new Option("reddit", "Reddit"),
+            new Option("imo", "imo"),
+            new Option("pinterest", "Pinterest"),
+            new Option("imgur", "Imgur"),
+            new Option("line", "Line"),
+            new Option("viber", "Viber"),
+            new Option("kakaotalk", "KakaoTalk"),
+            new Option("kakao_story", "KakaoStory"),
+            new Option("google_messages", "Google Messages"),
+            new Option("youtube", "YouTube"),
+            new Option("zalo", "Zalo"),
+            new Option("band", "Band"),
+            new Option("lemon8", "Lemon8"),
+            new Option("vk", "VK"),
+            new Option("more", "More (system share sheet)"),
+            new Option("upscrolled", "Upscrolled"),
+    };
+
+    private ShareChannelOptions() {
+    }
+
+    public static String defaultEnabledKeys() {
+        return "";
+    }
+
+    public static Set<String> parseEnabledKeys(String keys) {
+        return parseKeys(keys);
+    }
+
+    public static Set<String> parseObservedKeys(String keys) {
+        return parseKeys(keys);
+    }
+
+    private static Set<String> parseKeys(String keys) {
+        LinkedHashSet<String> parsed = new LinkedHashSet<>();
+        if (keys != null) {
+            for (String key : keys.split(",")) {
+                String normalized = normalizeSettingKey(key);
+                if (normalized != null) {
+                    parsed.add(normalized);
+                }
+            }
+        }
+        return parsed;
+    }
+
+    public static String serializeEnabledKeys(Set<String> keys) {
+        StringBuilder builder = new StringBuilder();
+        for (Option option : OPTIONS) {
+            appendKey(builder, keys, option.key);
+        }
+
+        for (String key : keys) {
+            if (findOption(key) == null) {
+                appendKey(builder, keys, key);
+            }
+        }
+        return builder.toString();
+    }
+
+    public static List<Option> optionsForKeys(Set<String> keys) {
+        ArrayList<Option> options = new ArrayList<>();
+        for (Option option : OPTIONS) {
+            if (keys.contains(option.key)) {
+                options.add(option);
+            }
+        }
+
+        for (String key : keys) {
+            if (findOption(key) == null) {
+                options.add(new Option(key, rawLabel(key)));
+            }
+        }
+
+        return options;
+    }
+
+    public static Option findOption(String key) {
+        String normalized = normalizeSettingKey(key);
+        if (normalized == null) {
+            return null;
+        }
+
+        for (Option option : OPTIONS) {
+            if (option.key.equals(normalized)) {
+                return option;
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeSettingKey(String key) {
+        if (key == null) {
+            return null;
+        }
+
+        String trimmed = key.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        for (Option option : OPTIONS) {
+            if (option.key.equalsIgnoreCase(trimmed)) {
+                return option.key;
+            }
+        }
+
+        if (trimmed.toUpperCase(Locale.US).startsWith(RAW_PREFIX)) {
+            return trimmed;
+        }
+
+        return trimmed.toLowerCase(Locale.US);
+    }
+
+    private static String rawLabel(String key) {
+        if (key == null) {
+            return "Unknown app";
+        }
+
+        String raw = key.startsWith(RAW_PREFIX) ? key.substring(RAW_PREFIX.length()) : key;
+        raw = raw.replace('_', ' ').trim();
+        if (raw.isEmpty()) {
+            return "Unknown app";
+        }
+
+        return raw.substring(0, 1).toUpperCase(Locale.US) + raw.substring(1);
+    }
+
+    private static void appendKey(StringBuilder builder, Set<String> keys, String key) {
+        if (!keys.contains(key)) {
+            return;
+        }
+
+        if (builder.length() > 0) {
+            builder.append(',');
+        }
+        builder.append(key);
+    }
+
+    public static final class Option {
+        public final String key;
+        public final String label;
+
+        private Option(String key, String label) {
+            this.key = key;
+            this.label = label;
+        }
+    }
+}

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/sharesheet/ShareSheetFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/sharesheet/ShareSheetFilter.java
@@ -1,0 +1,175 @@
+package app.morphe.extension.tiktok.sharesheet;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.settings.BooleanSetting;
+import app.morphe.extension.shared.settings.StringSetting;
+import app.morphe.extension.tiktok.settings.Settings;
+
+/**
+ * Filters the "Share via" and "Video Actions" lists TikTok builds on its
+ * {@code C1476000oVp} panel builder, and toggles "Send to" via the same builder's
+ * {@code LJJIIJZLJL} ("supports IM") field. Neither the builder nor its list-item types
+ * are on this module's compile classpath, so everything here is reflective.
+ */
+public final class ShareSheetFilter {
+
+    private ShareSheetFilter() {
+    }
+
+    public static void filterChannels(Object builder) {
+        filterList(
+                builder,
+                "LIZ",
+                "Share via",
+                Settings.SHARE_SHEET_CHANNELS,
+                Settings.SHARE_SHEET_CHANNELS_ENABLED,
+                Settings.SHARE_SHEET_CHANNELS_OBSERVED,
+                ShareChannelOptions::parseEnabledKeys,
+                ShareChannelOptions::parseObservedKeys,
+                ShareChannelOptions::serializeEnabledKeys
+        );
+    }
+
+    public static void filterActions(Object builder) {
+        filterList(
+                builder,
+                "LJFF",
+                "Video Actions",
+                Settings.SHARE_SHEET_ACTIONS,
+                Settings.SHARE_SHEET_ACTIONS_ENABLED,
+                Settings.SHARE_SHEET_ACTIONS_OBSERVED,
+                VideoActionOptions::parseEnabledKeys,
+                VideoActionOptions::parseObservedKeys,
+                VideoActionOptions::serializeEnabledKeys
+        );
+    }
+
+    public static void applySendToVisibility(Object builder) {
+        try {
+            if (builder == null || Settings.SHARE_SHEET_SEND_TO.get()) {
+                return;
+            }
+
+            Field supportImField = findField(builder.getClass(), "LJJIIJZLJL");
+            if (supportImField.getType() != boolean.class) {
+                Logger.printDebug(() -> "Share sheet Send to: LJJIIJZLJL was not a boolean, actual type="
+                        + supportImField.getType());
+                return;
+            }
+
+            supportImField.setBoolean(builder, false);
+        } catch (Throwable t) {
+            Logger.printException(() -> "Share sheet: send-to visibility override failed", t);
+        }
+    }
+
+    private static Field findField(Class<?> startClass, String fieldName) throws NoSuchFieldException {
+        for (Class<?> clazz = startClass; clazz != null; clazz = clazz.getSuperclass()) {
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException ignored) {
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void filterList(
+            Object builder,
+            String fieldName,
+            String label,
+            BooleanSetting masterToggle,
+            StringSetting enabledSetting,
+            StringSetting observedSetting,
+            Function<String, Set<String>> parseEnabledKeys,
+            Function<String, Set<String>> parseObservedKeys,
+            Function<Set<String>, String> serializeKeys
+    ) {
+        try {
+            if (builder == null) {
+                return;
+            }
+
+            Field field = builder.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object raw = field.get(builder);
+            if (!(raw instanceof List)) {
+                Logger.printDebug(() -> "Share sheet " + label + ": field " + fieldName
+                        + " was not a List, actual type=" + (raw == null ? "null" : raw.getClass().getName()));
+                return;
+            }
+            List<Object> list = (List<Object>) raw;
+
+            Set<String> previousObserved = parseObservedKeys.apply(observedSetting.get());
+            LinkedHashSet<String> observedNow = new LinkedHashSet<>(previousObserved);
+            LinkedHashSet<String> newlyObserved = new LinkedHashSet<>();
+            List<String> thisPassKeys = new ArrayList<>();
+            for (Object item : list) {
+                String key = itemKey(item);
+                thisPassKeys.add(key == null ? "<unknown:" + item.getClass().getName() + ">" : key);
+                if (key != null && observedNow.add(key)) {
+                    newlyObserved.add(key);
+                }
+            }
+
+            Logger.printDebug(() -> "Share sheet " + label + ": keys seen this pass=" + thisPassKeys
+                    + (newlyObserved.isEmpty() ? "" : ", newly observed=" + newlyObserved));
+
+            String observedSignature = serializeKeys.apply(observedNow);
+            if (!observedSignature.equals(observedSetting.get())) {
+                observedSetting.save(observedSignature);
+            }
+
+            if (!newlyObserved.isEmpty()) {
+                Set<String> enabledKeys = parseEnabledKeys.apply(enabledSetting.get());
+                if (enabledKeys.addAll(newlyObserved)) {
+                    enabledSetting.save(serializeKeys.apply(enabledKeys));
+                }
+            }
+
+            if (!masterToggle.get()) {
+                list.clear();
+                return;
+            }
+
+            Set<String> enabledKeys = parseEnabledKeys.apply(enabledSetting.get());
+            Iterator<Object> iterator = list.iterator();
+            while (iterator.hasNext()) {
+                String key = itemKey(iterator.next());
+                if (key == null || !enabledKeys.contains(key)) {
+                    iterator.remove();
+                }
+            }
+        } catch (Throwable t) {
+            Logger.printException(() -> "Share sheet: filtering failed for field " + fieldName, t);
+        }
+    }
+
+    private static String itemKey(Object item) {
+        if (item == null) {
+            return null;
+        }
+        try {
+            Method method = item.getClass().getMethod("key");
+            Object result = method.invoke(item);
+            if (result instanceof String) {
+                String key = ((String) result).trim();
+                return key.isEmpty() ? null : key;
+            }
+            return null;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+}

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/sharesheet/VideoActionOptions.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/sharesheet/VideoActionOptions.java
@@ -1,0 +1,170 @@
+package app.morphe.extension.tiktok.sharesheet;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * "Video Actions" keys as seen on other users' content. TikTok has no readable source for
+ * these, so they were captured live via {@link ShareSheetFilter}'s debug logging. Keys not
+ * seeded here are picked up automatically the first time they're observed.
+ * <p>
+ * The current account's own videos surface a different, mostly disjoint creator-only set
+ * (Analytics, Delete, Edit Post, ...) that's intentionally left out, since this allow-list
+ * is scoped to other people's content.
+ */
+public final class VideoActionOptions {
+    private static final String RAW_PREFIX = "RAW:";
+
+    public static final Option[] OPTIONS = {
+            new Option("report", "Report"),
+            new Option("dislike", "Not Interested"),
+            new Option("why_this_video", "Why This Post"),
+            new Option("duet", "Duet"),
+            new Option("stitch", "Stitch"),
+            new Option("save_photo", "Save Photo"),
+            new Option("save", "Save Video"),
+            new Option("gif", "Share as GIF"),
+            new Option("captions", "Captions"),
+            new Option("live_photo", "Set as Wallpaper"),
+            new Option("im_create_group", "Create Group"),
+            new Option("create_sticker", "Create Sticker"),
+            new Option("playback_speed", "Playback Speed"),
+            new Option("promote_for_others_fyp", "Promote"),
+            new Option("share_to_story", "Add to Story"),
+            new Option("show_in_chat", "Show in Chat"),
+    };
+
+    private VideoActionOptions() {
+    }
+
+    public static String defaultEnabledKeys() {
+        return "";
+    }
+
+    public static Set<String> parseEnabledKeys(String keys) {
+        return parseKeys(keys);
+    }
+
+    public static Set<String> parseObservedKeys(String keys) {
+        return parseKeys(keys);
+    }
+
+    private static Set<String> parseKeys(String keys) {
+        LinkedHashSet<String> parsed = new LinkedHashSet<>();
+        if (keys != null) {
+            for (String key : keys.split(",")) {
+                String normalized = normalizeSettingKey(key);
+                if (normalized != null) {
+                    parsed.add(normalized);
+                }
+            }
+        }
+        return parsed;
+    }
+
+    public static String serializeEnabledKeys(Set<String> keys) {
+        StringBuilder builder = new StringBuilder();
+        for (Option option : OPTIONS) {
+            appendKey(builder, keys, option.key);
+        }
+
+        for (String key : keys) {
+            if (findOption(key) == null) {
+                appendKey(builder, keys, key);
+            }
+        }
+        return builder.toString();
+    }
+
+    public static List<Option> optionsForKeys(Set<String> keys) {
+        ArrayList<Option> options = new ArrayList<>();
+        for (Option option : OPTIONS) {
+            if (keys.contains(option.key)) {
+                options.add(option);
+            }
+        }
+
+        for (String key : keys) {
+            if (findOption(key) == null) {
+                options.add(new Option(key, rawLabel(key)));
+            }
+        }
+
+        return options;
+    }
+
+    public static Option findOption(String key) {
+        String normalized = normalizeSettingKey(key);
+        if (normalized == null) {
+            return null;
+        }
+
+        for (Option option : OPTIONS) {
+            if (option.key.equals(normalized)) {
+                return option;
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeSettingKey(String key) {
+        if (key == null) {
+            return null;
+        }
+
+        String trimmed = key.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        for (Option option : OPTIONS) {
+            if (option.key.equalsIgnoreCase(trimmed)) {
+                return option.key;
+            }
+        }
+
+        if (trimmed.toUpperCase(Locale.US).startsWith(RAW_PREFIX)) {
+            return trimmed;
+        }
+
+        return trimmed.toLowerCase(Locale.US);
+    }
+
+    private static String rawLabel(String key) {
+        if (key == null) {
+            return "Unknown action";
+        }
+
+        String raw = key.startsWith(RAW_PREFIX) ? key.substring(RAW_PREFIX.length()) : key;
+        raw = raw.replace('_', ' ').trim();
+        if (raw.isEmpty()) {
+            return "Unknown action";
+        }
+
+        return raw.substring(0, 1).toUpperCase(Locale.US) + raw.substring(1);
+    }
+
+    private static void appendKey(StringBuilder builder, Set<String> keys, String key) {
+        if (!keys.contains(key)) {
+            return;
+        }
+
+        if (builder.length() > 0) {
+            builder.append(',');
+        }
+        builder.append(key);
+    }
+
+    public static final class Option {
+        public final String key;
+        public final String label;
+
+        private Option(String key, String label) {
+            this.key = key;
+            this.label = label;
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/sharesheet/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/sharesheet/Fingerprints.kt
@@ -1,0 +1,11 @@
+package app.morphe.patches.tiktok.misc.sharesheet
+
+import app.morphe.patcher.Fingerprint
+
+// Real dex class is X.0oVo; jadx renamed it to C1475990oVo for decompilation only.
+internal object SharePanelSnapshotConstructorFingerprint : Fingerprint(
+    definingClass = "LX/0oVo;",
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf("LX/0oVp;"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/sharesheet/ShareSheetPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/sharesheet/ShareSheetPatch.kt
@@ -1,0 +1,38 @@
+package app.morphe.patches.tiktok.misc.sharesheet
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
+import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
+
+private const val FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/sharesheet/ShareSheetFilter;"
+
+@Suppress("unused")
+val shareSheetPatch = bytecodePatch(
+    name = "Share sheet modification",
+    description = "Adds toggles and allow-lists for the video share sheet's \"Send to\", " +
+        "\"Share via app\", and \"Video Actions\" sections.",
+    default = true,
+) {
+    dependsOn(sharedExtensionPatch)
+
+    compatibleWith(*AppCompatibilities.tiktok4623())
+
+    execute {
+        SettingsStatusLoadFingerprint.method.addInstruction(
+            0,
+            "invoke-static {}, Lapp/morphe/extension/tiktok/settings/SettingsStatus;->enableShareSheet()V",
+        )
+
+        SharePanelSnapshotConstructorFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p1}, $FILTER_CLASS_DESCRIPTOR->filterChannels(Ljava/lang/Object;)V
+                invoke-static {p1}, $FILTER_CLASS_DESCRIPTOR->filterActions(Ljava/lang/Object;)V
+                invoke-static {p1}, $FILTER_CLASS_DESCRIPTOR->applySendToVisibility(Ljava/lang/Object;)V
+            """,
+        )
+    }
+}


### PR DESCRIPTION
Adds a "Share sheet modification" patch with independent controls for each section of the video share sheet:

- Send to: on/off toggle for the quick-share contact row.
- Share via app: on/off toggle plus an allow-list of which apps appear (Repost, Copy Link, WhatsApp, Discord, etc.).
- Video Actions: on/off toggle plus an allow-list of which actions appear (Report, Duet, Stitch, Playback Speed, etc.).

Both allow-lists auto-discover new items the first time TikTok shows them, so apps/actions added in future TikTok updates appear without needing a patch update, matching the existing Feed tab navigation patch's approach.

Closes #142 

Tested on [TikTok 46.2.3](https://www.apkmirror.com/apk/tiktok-pte-ltd/tik-tok-including-musical-ly/tiktok-46-2-3-release/tiktok-46-2-3-android-apk-download/):
- Toggling the "Send to" section off and observed that the "Send to" section doesn't display in the share sheet.
- Toggling the "Share via" section off and observed that the "Share via" section doesn't display in the share sheet.
- Toggling individual applications in the "Share via" section and observed that they were no longer displayed in the "Share via" section in the share sheet.
- Toggling the "Video actions" section off and observed that the "Video actions" section doesn't display in the share sheet.
- Toggling individual actions in the "Video actions" section and observed that they were no longer displayed in the "Video actions" section in the share sheet.

Note: That the share sheet has to be opened at least once for the settings menu to populate with the applications/actions, and that the TikTok app has more apps listed in the code then they actually display.