### PR TITLE
feat: Side-by-Side Comment View on Foldables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The goal is to keep the existing patch set usable while adding more TikTok-focus
 | `Feed filter` | Hides feed ads, TikTok Shop items, livestreams, stories, photo posts, and videos outside configured view or like ranges, with optional filtering of cached and offline FYP fallback videos. |
 | `Feed tab navigation` | Controls which loaded top and bottom navigation tabs remain visible, blocks newly added tabs when requested, and can hide the Tako AI bubble. |
 | `Fix Google login` | Restores Google account sign-in after patching. |
+| `Foldable split comment view` | Forces TikTok's tablet-style split layout, showing comments beside the video instead of as a bottom sheet, once the screen is at least as wide as a configurable threshold (600dp by default). Intended for foldables TikTok doesn't already treat as tablet-class. |
 | `Hide CAPTCHA popups` | Hides non-account verification puzzle dialogs, including those shown while browsing LIVE. Account verification remains available, and server checks are not bypassed. |
 | `Hide floating promotions` | Removes floating promotional badges, coin icons, and timer banners from the Home feed. |
 | `Hide quick comment reactions` | Hides TikTok's exposed quick emoji row in supported comment inputs. |

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/foldable/FoldableSplitView.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/foldable/FoldableSplitView.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 icysymmetra/tiktok-patches-for-morphe contributors
+ * https://github.com/icysymmetra/tiktok-patches-for-morphe
+ */
+package app.morphe.extension.tiktok.foldable;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Point;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.WindowManager;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.tiktok.settings.Settings;
+
+@SuppressWarnings("unused")
+public final class FoldableSplitView {
+    /**
+     * Tracks whether the last evaluation forced split mode. TikTok's own live re-layout for the
+     * comment panel is asymmetric: it correctly collapses back to a bottom sheet on any
+     * configuration change while already split, but only expands into split mode through a code
+     * path gated behind TikTok's own tablet/fold classification, which never fires for real
+     * foldable hardware. So a bottom-sheet-to-split transition while the app is already running
+     * never gets picked up on its own; the same layout only comes out correct on a fresh bind
+     * (app cold start, or a fresh Activity). This flag lets us detect exactly that transition
+     * (false -> true) and force a rebuild via that same, already-correct fresh-bind path.
+     */
+    private static final AtomicBoolean lastForced = new AtomicBoolean(false);
+    private static final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    private FoldableSplitView() {}
+
+    /**
+     * Hooked into X.0oq9->LIZ(Activity, Configuration), TikTok's live "isOptCommentSplit" check.
+     */
+    public static boolean shouldForceCommentSplit(Activity activity, Configuration configuration) {
+        if (!Settings.FOLDABLE_SPLIT_VIEW.get()) {
+            return false;
+        }
+
+        if (activity != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+                && (activity.isInMultiWindowMode() || activity.isInPictureInPictureMode())) {
+            Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] shouldForceCommentSplit"
+                    + " skipped, activity is in multi-window or picture-in-picture mode");
+            return false;
+        }
+
+        Activity windowActivity = activity != null ? activity : Utils.getActivity();
+        return evaluate("shouldForceCommentSplit", resolveScreenWidthDp(windowActivity, configuration), windowActivity);
+    }
+
+    /**
+     * Hooked into X.0oq9->LIZJ(), TikTok's cached "isOptSplitContainer" check.
+     */
+    public static boolean shouldForceCommentSplitContainer() {
+        if (!Settings.FOLDABLE_SPLIT_VIEW.get()) {
+            return false;
+        }
+
+        Activity windowActivity = Utils.getActivity();
+        return evaluate("shouldForceCommentSplitContainer", resolveScreenWidthDp(windowActivity, null), windowActivity);
+    }
+
+    private static boolean evaluate(String source, int widthDp, Activity windowActivity) {
+        int thresholdDp = Settings.FOLDABLE_SPLIT_VIEW_MIN_WIDTH_DP.get();
+        boolean force = widthDp > 0 && widthDp >= thresholdDp;
+        Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] " + source
+                + " widthDp=" + widthDp + " thresholdDp=" + thresholdDp + " force=" + force);
+
+        if (force) {
+            if (lastForced.compareAndSet(false, true)) {
+                onWidenTransitionDetected(windowActivity);
+            }
+        } else {
+            lastForced.set(false);
+        }
+
+        return force;
+    }
+
+    /**
+     * Forces a full Activity rebuild so the comment layout gets rebound through the same
+     * (already-correct) path used on a fresh app launch, since TikTok's own live re-layout
+     * doesn't pick up a bottom-sheet-to-split transition on its own. Deferred to the next main
+     * thread loop iteration, since this runs from inside TikTok's own configuration-change
+     * handling and recreating the Activity reentrantly from that same call stack is unsafe.
+     */
+    private static void onWidenTransitionDetected(Activity activity) {
+        Activity target = activity != null ? activity : Utils.getActivity();
+        if (target == null) {
+            Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] widen transition detected"
+                    + " but no activity is available to recreate");
+            return;
+        }
+
+        Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] widen transition detected,"
+                + " recreating activity to rebuild the comment layout");
+        mainHandler.post(() -> {
+            try {
+                target.recreate();
+            } catch (Exception ex) {
+                Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] activity recreate failed", ex);
+            }
+        });
+    }
+
+    /**
+     * Prefers a fresh, live measurement of the current window over any passed-in or cached
+     * Configuration snapshot. On cold app launch, the first Configuration TikTok (or we) can
+     * read is sometimes stale and hasn't yet settled to the device's true current fold posture.
+     * Querying WindowManager directly avoids relying on that snapshot having already propagated.
+     */
+    private static int resolveScreenWidthDp(Activity windowActivity, Configuration configuration) {
+        int liveWidthDp = measureLiveWidthDp(windowActivity);
+        if (liveWidthDp > 0) {
+            return liveWidthDp;
+        }
+
+        if (configuration != null) {
+            return configuration.screenWidthDp;
+        }
+
+        try {
+            Context fallbackContext = windowActivity != null ? windowActivity : Utils.getContext();
+            if (fallbackContext == null) {
+                return 0;
+            }
+            return fallbackContext.getResources().getConfiguration().screenWidthDp;
+        } catch (Exception ex) {
+            Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] resolveScreenWidthDp fallback failed", ex);
+            return 0;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static int measureLiveWidthDp(Activity activity) {
+        if (activity == null) {
+            return 0;
+        }
+
+        try {
+            WindowManager windowManager = activity.getWindowManager();
+            if (windowManager == null) {
+                return 0;
+            }
+
+            int widthPx;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                widthPx = windowManager.getCurrentWindowMetrics().getBounds().width();
+            } else {
+                Point size = new Point();
+                windowManager.getDefaultDisplay().getRealSize(size);
+                widthPx = size.x;
+            }
+
+            float density = activity.getResources().getDisplayMetrics().density;
+            if (widthPx <= 0 || density <= 0) {
+                return 0;
+            }
+            return Math.round(widthPx / density);
+        } catch (Exception ex) {
+            Logger.printDebug(() -> "[Morphe TikTok FoldableSplitView] measureLiveWidthDp failed", ex);
+            return 0;
+        }
+    }
+}

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
@@ -119,6 +119,13 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting OPEN_EXTERNAL_LINKS = new BooleanSetting("open_external_links", TRUE);
     public static final BooleanSetting ALWAYS_SHOW_PUBLISH_DATE = new BooleanSetting("always_show_publish_date", TRUE, true);
     public static final BooleanSetting CLEAR_DISPLAY = new BooleanSetting("clear_display", FALSE);
+    public static final BooleanSetting FOLDABLE_SPLIT_VIEW = new BooleanSetting("foldable_split_view", FALSE, true);
+    public static final IntegerSetting FOLDABLE_SPLIT_VIEW_MIN_WIDTH_DP = new IntegerSetting(
+            "foldable_split_view_min_width_dp",
+            600,
+            true,
+            Setting.parent(FOLDABLE_SPLIT_VIEW)
+    );
     public static final BooleanSetting COPY_COMMENTS_WITHOUT_USERNAME = new BooleanSetting("copy_comments_without_username", TRUE);
     public static final FloatSetting REMEMBERED_SPEED = new FloatSetting("remembered_speed_v2", 1.0f);
     public static final BooleanSetting ENABLE_LONG_PRESS_SPEED_LOCK = new BooleanSetting("enable_long_press_speed_lock", FALSE, true);

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
@@ -25,6 +25,7 @@ public class SettingsStatus {
     public static boolean resumeVideoAfterScrollEnabled = false;
     public static boolean externalBrowserEnabled = false;
     public static boolean alwaysShowPublishDateEnabled = false;
+    public static boolean foldableSplitViewEnabled = false;
     public static boolean diagnosticsEnabled = false;
 
     public static void enableFeedFilter() {
@@ -101,6 +102,10 @@ public class SettingsStatus {
 
     public static void enableAlwaysShowPublishDate() {
         alwaysShowPublishDateEnabled = true;
+    }
+
+    public static void enableFoldableSplitView() {
+        foldableSplitViewEnabled = true;
     }
 
     public static void enableDiagnostics() {

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/TikTokPreferenceFragment.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/TikTokPreferenceFragment.java
@@ -454,6 +454,9 @@ public class TikTokPreferenceFragment extends AbstractPreferenceFragment {
                 && Settings.DISABLE_LONG_PRESS_REPOST.get()) {
             count++;
         }
+        if (SettingsStatus.foldableSplitViewEnabled && Settings.FOLDABLE_SPLIT_VIEW.get()) {
+            count++;
+        }
         return count;
     }
 

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ExtensionPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ExtensionPreferenceCategory.java
@@ -11,6 +11,7 @@ import android.preference.PreferenceScreen;
 import app.morphe.extension.shared.settings.BaseSettings;
 import app.morphe.extension.tiktok.settings.Settings;
 import app.morphe.extension.tiktok.settings.SettingsStatus;
+import app.morphe.extension.tiktok.settings.preference.NumberInputPreference;
 import app.morphe.extension.tiktok.settings.preference.TogglePreference;
 
 @SuppressWarnings("deprecation")
@@ -110,6 +111,26 @@ public class ExtensionPreferenceCategory extends ConditionalPreferenceCategory {
                     "Show Live search",
                     "Show TikTok's search entry in the Live drawer where supported.",
                     Settings.ENABLE_LIVE_SEARCH
+            ));
+        }
+        if (SettingsStatus.foldableSplitViewEnabled) {
+            addPreference(new TogglePreference(
+                    context,
+                    "Force split video/comment view",
+                    "Show comments beside the video instead of as a bottom sheet once the screen is at least "
+                            + "as wide as the threshold below. Intended for foldables TikTok doesn't already "
+                            + "treat as tablet-class. Requires restart.",
+                    Settings.FOLDABLE_SPLIT_VIEW
+            ));
+            addPreference(new NumberInputPreference(
+                    context,
+                    "Split view width threshold (dp)",
+                    "Minimum screen width, in dp, before the split view is forced. Export a diagnostic report "
+                            + "after opening a video's comments to see your device's measured width. "
+                            + "Requires restart.",
+                    Settings.FOLDABLE_SPLIT_VIEW_MIN_WIDTH_DP,
+                    200,
+                    1200
             ));
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/foldable/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/foldable/Fingerprints.kt
@@ -1,0 +1,20 @@
+package app.morphe.patches.tiktok.misc.foldable
+
+import app.morphe.patcher.Fingerprint
+
+// Real dex class is X.0oq9; jadx renamed it to C1488600oq9 for decompilation only.
+internal object CommentSplitLiveCheckFingerprint : Fingerprint(
+    definingClass = "LX/0oq9;",
+    name = "LIZ",
+    returnType = "Z",
+    parameters = listOf("Landroid/app/Activity;", "Landroid/content/res/Configuration;"),
+    strings = listOf("isOptCommentSplit"),
+)
+
+internal object CommentSplitContainerCheckFingerprint : Fingerprint(
+    definingClass = "LX/0oq9;",
+    name = "LIZJ",
+    returnType = "Z",
+    parameters = listOf(),
+    strings = listOf("isOptSplitContainer"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/foldable/ForceFoldableSplitViewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/foldable/ForceFoldableSplitViewPatch.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 icysymmetra/tiktok-patches-for-morphe contributors
+ * https://github.com/icysymmetra/tiktok-patches-for-morphe
+ */
+package app.morphe.patches.tiktok.misc.foldable
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
+import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
+
+private const val EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/foldable/FoldableSplitView;"
+
+@Suppress("unused")
+val foldableSplitViewPatch = bytecodePatch(
+    name = "Foldable split comment view",
+    description = "Forces TikTok's tablet-style split layout (video beside comments instead of a bottom sheet) " +
+        "once the screen is at least as wide as a configurable threshold, for foldables TikTok doesn't " +
+        "already recognize as tablet-class.",
+    default = true,
+) {
+    dependsOn(sharedExtensionPatch)
+
+    compatibleWith(*AppCompatibilities.tiktok4623())
+
+    execute {
+        SettingsStatusLoadFingerprint.method.addInstruction(
+            0,
+            "invoke-static {}, Lapp/morphe/extension/tiktok/settings/SettingsStatus;->enableFoldableSplitView()V",
+        )
+
+        CommentSplitLiveCheckFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p0, p1}, $EXTENSION_CLASS_DESCRIPTOR->shouldForceCommentSplit(Landroid/app/Activity;Landroid/content/res/Configuration;)Z
+                move-result v0
+                if-eqz v0, :morphe_stock_comment_split_check
+                const/4 v0, 0x1
+                return v0
+                :morphe_stock_comment_split_check
+                nop
+            """,
+        )
+
+        CommentSplitContainerCheckFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {}, $EXTENSION_CLASS_DESCRIPTOR->shouldForceCommentSplitContainer()Z
+                move-result v0
+                if-eqz v0, :morphe_stock_split_container_check
+                const/4 v0, 0x1
+                return v0
+                :morphe_stock_split_container_check
+                nop
+            """,
+        )
+    }
+}


### PR DESCRIPTION
Adds a "Side-by-Side Comment Section" patch with manual adjustment of the DPI threshold if desired.

Closes #144

Tested on [TikTok 46.2.3](https://www.apkmirror.com/apk/tiktok-pte-ltd/tik-tok-including-musical-ly/tiktok-46-2-3-release/tiktok-46-2-3-android-apk-download/):
- App fully closed, device in folded state, open TikTok and comment section -> comment section overlays video ✅
- App fully closed, device in folded state, open TikTok and comment section, unfold device, open comment section -> comment section side-by-side with video ✅
- App fully closed, device in folded state, open TikTok and comment section, unfold device, open comment section, fold device, open comment section -> comment section overlays video ✅

- App fully closed, device in unfolded state, open TikTok and comment section -> comment section side-by-side with video ✅
- App fully closed, device in unfolded state, open TikTok and comment section, fold device, open comment section -> comment section overlays video ✅
- App fully closed, device in unfolded state, open TikTok and comment section, fold device, open comment section, unfold device, open comment section -> comment section side-by-side with video ✅

[Testing Folded to Unfolded State](https://imgur.com/a/RPXEYid)
[Testing Unfolded to Folded State](https://imgur.com/a/eiXNZ0d)

Note: In order to correctly get the side-by-side comment section when unfolded, there has the be a reload of the UI in order to capture the state correctly. This means that when going from the folded to unfolded state there will be a brief lag/flash before the video starts to play.